### PR TITLE
Normalize count vectors in computing objective functions

### DIFF
--- a/kmerexpr/multinomial_model.py
+++ b/kmerexpr/multinomial_model.py
@@ -83,6 +83,7 @@ class multinomial_model:
             y = np.load(y_file)
         self.ymask = y.nonzero() # Need only need self.ynnz and self.xnnz. Throw away the rest?
         self.ynnz = y[self.ymask]
+        self.ynnz = self.ynnz / np.sum(self.ynnz)
         self.xnnz = x[self.ymask]
         self.N = np.sum(y)
         self.name = "softmax"

--- a/kmerexpr/multinomial_simplex_model.py
+++ b/kmerexpr/multinomial_simplex_model.py
@@ -60,6 +60,7 @@ class multinomial_simplex_model:
             y = np.load(y_file)
         self.ymask = y.nonzero() # Need only need self.ynnz and self.xnnz. Throw away the rest?
         self.ynnz = y[self.ymask]
+        self.ynnz = self.ynnz / np.sum(self.ynnz)
         self.xnnz = x[self.ymask]
         self.N = np.sum(y)
         self.beta = beta


### PR DESCRIPTION
Normalization of count vectors used in the objective functions to make objective and parameters values comparable across optimizers (discussed with @gowerrobert)
