### PR TITLE
Save count vectors in sparse format

### DIFF
--- a/kmerexpr/multinomial_model.py
+++ b/kmerexpr/multinomial_model.py
@@ -19,10 +19,10 @@
 # pulls the testing out.
 
 import numpy as np
-from scipy.sparse import load_npz
 from scipy.special import softmax as softmax
 from scipy import optimize
 import time
+from kmerexpr.rna_seq_reader import load_xy
 
 # BMW: Class names are usually done in CamelCase style
 class multinomial_model:
@@ -76,11 +76,7 @@ class multinomial_model:
         y -- vector of k-mer counts
         beta -- parameter for prior
         """
-        x = load_npz(x_file)
-        if(isinstance(y_file, np.ndarray)):
-            y = y_file
-        else:
-            y = np.load(y_file)
+        x, y = load_xy(x_file, y_file)
         self.ymask = y.nonzero() # Need only need self.ynnz and self.xnnz. Throw away the rest?
         self.ynnz = y[self.ymask]
         self.xnnz = x[self.ymask]

--- a/kmerexpr/multinomial_simplex_model.py
+++ b/kmerexpr/multinomial_simplex_model.py
@@ -1,11 +1,10 @@
 import numpy as np
-from scipy.sparse import load_npz
 from scipy.sparse.linalg import lsqr
 from scipy import optimize
 from kmerexpr.exp_grad_solver import exp_grad_solver
 from scipy.special import softmax as softmax
 from kmerexpr.frank_wolfe import frank_wolfe_solver
-
+from kmerexpr.rna_seq_reader import load_xy
 
 
 # BMW: Class names are usually done in CamelCase style
@@ -53,11 +52,7 @@ class multinomial_simplex_model:
         lengths -- an array of the lengths of the isoforms
         solver_name -- a string that is either mirror_bfgs or exp_grad, which are the two available solvers for fitting the model
         """
-        x = load_npz(x_file)
-        if(isinstance(y_file, np.ndarray)):
-            y = y_file
-        else:
-            y = np.load(y_file)
+        x, y = load_xy(x_file, y_file)
         self.ymask = y.nonzero() # Need only need self.ynnz and self.xnnz. Throw away the rest?
         self.ynnz = y[self.ymask]
         self.xnnz = x[self.ymask]

--- a/kmerexpr/normal_model.py
+++ b/kmerexpr/normal_model.py
@@ -1,9 +1,9 @@
 import numpy as np
-from scipy.sparse import load_npz
 from scipy.special import softmax as softmax
 from scipy import optimize
 import time
 from scipy.sparse.linalg import lsqr
+from kmerexpr.rna_seq_reader import load_xy
 
 # BMW: Class names are usually done in CamelCase style
 class normal_model:
@@ -45,11 +45,7 @@ class normal_model:
         y -- vector of k-mer counts
         N -- total number of k-mers
         """
-        self.x = load_npz(x_file)
-        if(isinstance(y_file, np.ndarray)):
-            self.y = y_file
-        else:
-            self.y = np.load(y_file)
+        self.x, self.y = load_xy(x_file, y_file)
         self.N = np.sum(self.y)
         self.beta = beta
         self.name = "normal"

--- a/kmerexpr/rna_seq_reader.py
+++ b/kmerexpr/rna_seq_reader.py
@@ -2,6 +2,7 @@ import numpy as np
 from collections import Counter
 from kmerexpr.transcriptome_reader import valid_kmer, shred, kmer_to_id
 from kmerexpr import fasta
+from scipy.sparse import load_npz
 
 def reads_to_y(K, READS_FILE, float_t=np.float32, int_t=np.int32, Y_FILE = None):
     print("K =", K)
@@ -27,3 +28,12 @@ def reads_to_y(K, READS_FILE, float_t=np.float32, int_t=np.int32, Y_FILE = None)
     if Y_FILE is not None:
         np.save(Y_FILE, y)
     return y
+
+
+def load_xy(x_file, y_file):
+    x = load_npz(x_file)
+    if isinstance(y_file, np.ndarray):
+        y = y_file
+    else:
+        y = np.load(y_file)
+    return x, y

--- a/kmerexpr/rna_seq_reader.py
+++ b/kmerexpr/rna_seq_reader.py
@@ -2,7 +2,7 @@ import numpy as np
 from collections import Counter
 from kmerexpr.transcriptome_reader import valid_kmer, shred, kmer_to_id
 from kmerexpr import fasta
-from scipy.sparse import load_npz
+from scipy.sparse import load_npz, save_npz, coo_matrix
 
 def reads_to_y(K, READS_FILE, float_t=np.float32, int_t=np.int32, Y_FILE = None):
     print("K =", K)
@@ -26,7 +26,7 @@ def reads_to_y(K, READS_FILE, float_t=np.float32, int_t=np.int32, Y_FILE = None)
                 y[id] += count
             n += 1
     if Y_FILE is not None:
-        np.save(Y_FILE, y)
+        save_npz(Y_FILE, coo_matrix(y))
     return y
 
 
@@ -35,5 +35,5 @@ def load_xy(x_file, y_file):
     if isinstance(y_file, np.ndarray):
         y = y_file
     else:
-        y = np.load(y_file)
+        y = load_npz(y_file).toarray().squeeze()
     return x, y

--- a/kmerexpr/utils.py
+++ b/kmerexpr/utils.py
@@ -23,7 +23,7 @@ class Problem:
         READS_FILE = prefix + "READS-" + surfix + ".fna"
         X_FILE = prefix + "X-" + surfix + "-" + str(self.K) + "_csr.npz"
         Y_FILE = prefix + "Y-" + surfix + "-" + str(self.K)
-        Y_FILE = Y_FILE +"-a-" +str(self.alpha) + ".npy"
+        Y_FILE = Y_FILE +"-a-" +str(self.alpha) + ".npz"
         READS_FILE =  READS_FILE +"-a-" +str(self.alpha) + ".fna"
         return ISO_FILE, READS_FILE, X_FILE, Y_FILE
         


### PR DESCRIPTION
The count vectors are currently saved in dense format, leading to storage issues when running many different settings. 
(I'm hitting `200GB` of experiment files)

This change saves the data in sparse format (dense files of `2.0GB` go to sparse files of `<1MB` for k-mers of size 14).

The load function still returns dense vectors to not impact the code in other places.

